### PR TITLE
Arreglar alto de linea

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -2,6 +2,7 @@ body {
 	background: #008082;
 	font-family: sans-serif, serif, monospace;
 	font-size: 13px;
+	line-height: normal;
 }
 
 .wrapper, .content {


### PR DESCRIPTION
esto hace que la g, la p, la q, y otras letras que cuelgan no se vean cortadas